### PR TITLE
Fix GCC compiling errors

### DIFF
--- a/src/game/editor/editor2.h
+++ b/src/game/editor/editor2.h
@@ -39,14 +39,14 @@ struct array2: public array<T>
 
 	inline T& add(const T& Elt)
 	{
-		return base_ptr()[ParentT::add(Elt)];
+		return this->base_ptr()[ParentT::add(Elt)];
 	}
 
 	T& add(const T* aElements, int EltCount)
 	{
 		for(int i = 0; i < EltCount; i++)
 			ParentT::add(aElements[i]);
-		return *(base_ptr()+size()-EltCount);
+		return *(this->base_ptr()+this->size()-EltCount);
 	}
 
 	T& add_empty(int EltCount)
@@ -54,19 +54,19 @@ struct array2: public array<T>
 		dbg_assert(EltCount > 0, "Add 0 or more");
 		for(int i = 0; i < EltCount; i++)
 			ParentT::add(T());
-		return *(base_ptr()+size()-EltCount);
+		return *(this->base_ptr()+this->size()-EltCount);
 	}
 
 	inline void remove_index_fast(int Index)
 	{
-		dbg_assert(Index >= 0 && Index < size(), "Index out of bounds");
+		dbg_assert(Index >= 0 && Index < this->size(), "Index out of bounds");
 		ParentT::remove_index_fast(Index);
 	}
 
 	// keeps order, way slower
 	inline void remove_index(int Index)
 	{
-		dbg_assert(Index >= 0 && Index < size(), "Index out of bounds");
+		dbg_assert(Index >= 0 && Index < this->size(), "Index out of bounds");
 		ParentT::remove_index(Index);
 	}
 


### PR DESCRIPTION
Fixes those errors on current branch d8b47c013f204288880b93402af9c5d2d45cd4c9 with gcc: 
```
[1/2] [4] c++ src/game/editor/editor2.cpp
In file included from src/game/editor/editor2.cpp:2:0:
src/game/editor/editor2.h: In member function ‘T& array2<T>::add(const T&)’:
src/game/editor/editor2.h:42:19: error: there are no arguments to ‘base_ptr’ that depend on a template parameter, so a declaration of ‘base_ptr’ must be available [-fpermissive]
   return base_ptr()[ParentT::add(Elt)];
                   ^
src/game/editor/editor2.h:42:19: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
src/game/editor/editor2.h: In member function ‘T& array2<T>::add(const T*, int)’:
src/game/editor/editor2.h:49:21: error: there are no arguments to ‘base_ptr’ that depend on a template parameter, so a declaration of ‘base_ptr’ must be available [-fpermissive]
   return *(base_ptr()+size()-EltCount);
                     ^
src/game/editor/editor2.h:49:28: error: there are no arguments to ‘size’ that depend on a template parameter, so a declaration of ‘size’ must be available [-fpermissive]
   return *(base_ptr()+size()-EltCount);
                            ^
src/game/editor/editor2.h: In member function ‘T& array2<T>::add_empty(int)’:
src/game/editor/editor2.h:57:21: error: there are no arguments to ‘base_ptr’ that depend on a template parameter, so a declaration of ‘base_ptr’ must be available [-fpermissive]
   return *(base_ptr()+size()-EltCount);
                     ^
src/game/editor/editor2.h:57:28: error: there are no arguments to ‘size’ that depend on a template parameter, so a declaration of ‘size’ must be available [-fpermissive]
   return *(base_ptr()+size()-EltCount);
                            ^
In file included from src/game/editor/editor2.h:7:0,
                 from src/game/editor/editor2.cpp:2:
src/game/editor/editor2.h: In member function ‘void array2<T>::remove_index_fast(int)’:
src/game/editor/editor2.h:62:41: error: there are no arguments to ‘size’ that depend on a template parameter, so a declaration of ‘size’ must be available [-fpermissive]
   dbg_assert(Index >= 0 && Index < size(), "Index out of bounds");
                                         ^
src/base/system.h:40:65: note: in definition of macro ‘dbg_assert’
 #define dbg_assert(test,msg) dbg_assert_imp(__FILE__, __LINE__, test, msg)
                                                                 ^
src/game/editor/editor2.h: In member function ‘void array2<T>::remove_index(int)’:
src/game/editor/editor2.h:69:41: error: there are no arguments to ‘size’ that depend on a template parameter, so a declaration of ‘size’ must be available [-fpermissive]
   dbg_assert(Index >= 0 && Index < size(), "Index out of bounds");
                                         ^
src/base/system.h:40:65: note: in definition of macro ‘dbg_assert’
 #define dbg_assert(test,msg) dbg_assert_imp(__FILE__, __LINE__, test, msg)
                                                                 ^
bam: 'c++ src/game/editor/editor2.cpp' error 256
bam: error: a build step failed
```