### PR TITLE
Add a top panel with a file menu, move tool buttons up, add page switcher for the asset manager

### DIFF
--- a/src/game/editor/editor2.cpp
+++ b/src/game/editor/editor2.cpp
@@ -2336,6 +2336,8 @@ void CEditor2::RenderMapOverlay()
 
 void CEditor2::RenderTopPanel(CUIRect TopPanel)
 {
+	DrawRect(TopPanel, StyleColorBg);
+
 	CUIRect ButtonRect;
 	TopPanel.VSplitLeft(50.0f, &ButtonRect, &TopPanel);
 
@@ -2355,21 +2357,36 @@ void CEditor2::RenderTopPanel(CUIRect TopPanel)
 	}
 
 	// tools
-	TopPanel.VSplitLeft(50.0f, 0, &TopPanel);
-	static CUIButton s_ButTools[TOOL_COUNT_];
-	const char* aButName[] = {
-		"Se",
-		"Di",
-		"TB"
-	};
-
-	for(int t = 0; t < TOOL_COUNT_; t++)
+	if(m_Page == PAGE_MAP_EDITOR)
 	{
-		TopPanel.VSplitLeft(25.0f, &ButtonRect, &TopPanel);
+		TopPanel.VSplitLeft(50.0f, 0, &TopPanel);
+		static CUIButton s_ButTools[TOOL_COUNT_];
+		const char* aButName[] = {
+			"Se",
+			"Di",
+			"TB"
+		};
 
-		// if(UiButtonSelect(ButtonRect, aButName[t], &s_ButTools[t], m_Tool == t))
-		if(UiButtonEx(ButtonRect, aButName[t], &s_ButTools[t], m_Tool == t ? StyleColorInputSelected : StyleColorButton, m_Tool == t ? StyleColorInputSelected : StyleColorButtonHover, StyleColorButtonPressed, StyleColorButtonBorder, 10.0f))
-			ChangeTool(t);
+		for(int t = 0; t < TOOL_COUNT_; t++)
+		{
+			TopPanel.VSplitLeft(25.0f, &ButtonRect, &TopPanel);
+			if(UiButtonEx(ButtonRect, aButName[t], &s_ButTools[t], m_Tool == t ? StyleColorInputSelected : StyleColorButton, m_Tool == t ? StyleColorInputSelected : StyleColorButtonHover, StyleColorButtonPressed, StyleColorButtonBorder, 10.0f))
+				ChangeTool(t);
+		}
+	}
+
+	TopPanel.VSplitRight(20.0f, &TopPanel, 0);
+	TopPanel.VSplitRight(120.0f, &TopPanel, &ButtonRect);
+	static CUIButton s_PageSwitchButton;
+	if(m_Page == PAGE_MAP_EDITOR)
+	{
+		if(UiButton(ButtonRect, "Go to Asset Manager", &s_PageSwitchButton))
+			ChangePage(PAGE_ASSET_MANAGER);
+	}
+	else if(m_Page == PAGE_ASSET_MANAGER)
+	{
+		if(UiButton(ButtonRect, "Go to Map Editor", &s_PageSwitchButton))
+			ChangePage(PAGE_MAP_EDITOR);
 	}
 }
 
@@ -2382,7 +2399,6 @@ void CEditor2::RenderMapEditorUI()
 	UiScreenRect.VSplitRight(150.0f, &m_UiMainViewRect, &RightPanel);
 	m_UiMainViewRect.HSplitTop(20.0f, &TopPanel, &m_UiMainViewRect);
 
-	DrawRect(TopPanel, StyleColorBg);
 	RenderTopPanel(TopPanel);
 
 	DrawRect(RightPanel, StyleColorBg);
@@ -4043,8 +4059,9 @@ void CEditor2::RenderAssetManager()
 	const CUIRect UiScreenRect = m_UiScreenRect;
 	Graphics()->MapScreen(UiScreenRect.x, UiScreenRect.y, UiScreenRect.w, UiScreenRect.h);
 
-	CUIRect RightPanel, MainViewRect;
-	UiScreenRect.VSplitRight(150, &MainViewRect, &RightPanel);
+	CUIRect TopPanel, RightPanel, MainViewRect;
+	UiScreenRect.VSplitRight(150.0f, &MainViewRect, &RightPanel);
+	MainViewRect.HSplitTop(20.0f, &TopPanel, &MainViewRect);
 
 	DrawRect(RightPanel, StyleColorBg);
 
@@ -4185,6 +4202,8 @@ void CEditor2::RenderAssetManager()
 
 	if(m_UiSelectedImageID >= Assets.m_ImageCount)
 		m_UiSelectedImageID = -1;
+
+	RenderTopPanel(TopPanel);
 }
 
 inline void CEditor2::DrawRect(const CUIRect& Rect, const vec4& Color)

--- a/src/game/editor/editor2.h
+++ b/src/game/editor/editor2.h
@@ -355,10 +355,12 @@ class CEditor2: public IEditor
 	enum
 	{
 		POPUP_NONE = -1,
-		POPUP_BRUSH_PALETTE = 0
+		POPUP_BRUSH_PALETTE = 0,
+		POPUP_MENU_FILE,
 	};
 
 	int m_UiCurrentPopupID = POPUP_NONE;
+	CUIRect m_UiCurrentPopupRect;
 
 	struct CUIBrushPaletteState
 	{
@@ -481,8 +483,10 @@ class CEditor2: public IEditor
 	void RenderMap();
 	void RenderMapOverlay();
 	void RenderMapEditorUI();
+	void RenderTopPanel(CUIRect TopPanel);
 	void RenderMapEditorUiLayerGroups(CUIRect NavRect);
 	void RenderMapEditorUiDetailPanel(CUIRect DetailRect);
+	void RenderPopupMenuFile();
 	void RenderPopupBrushPalette();
 	void RenderBrush(vec2 Pos);
 
@@ -582,6 +586,7 @@ class CEditor2: public IEditor
 	bool UiScrollRegionIsRectClipped(CScrollRegion* pSr, const CUIRect& Rect);
 
 	inline bool IsPopupBrushPalette() const { return m_UiCurrentPopupID == POPUP_BRUSH_PALETTE; }
+	inline bool IsPopupMenuFile() const { return m_UiCurrentPopupID == POPUP_MENU_FILE; }
 
 	void Reset();
 	void ResetCamera();


### PR DESCRIPTION
Fixes https://github.com/LordSk/teeworlds/issues/17

- Add a top panel, always visible, **below** the right panel (as in, the right panel does not get moved down)
- Add a File menu: only `Exit` works for now, file dialogs need to be used for the rest. Maybe implement the new "Open Current Map in Editor" thing from the old editor.
![image](https://user-images.githubusercontent.com/355114/57776936-fe436800-7720-11e9-9131-cc668263083f.png)
- Move buttons up there, changed the style from 
![image](https://user-images.githubusercontent.com/355114/57776873-dbb14f00-7720-11e9-9e8f-58c0980d3c31.png) to ![image](https://user-images.githubusercontent.com/355114/57776890-e5d34d80-7720-11e9-894b-4dec096b5b72.png)
I left the old buttons up so you can choose
- Add a button to switch page (swap between Map editor and Asset manager, #17)
![image](https://user-images.githubusercontent.com/355114/57777031-2763f880-7721-11e9-8784-f385b9837e28.png)
![image](https://user-images.githubusercontent.com/355114/57777047-2df27000-7721-11e9-9859-fd0d0c2d75cb.png)
